### PR TITLE
Improved walled unlocking shard selection behavior:

### DIFF
--- a/hermit/shards/interface.py
+++ b/hermit/shards/interface.py
@@ -53,17 +53,24 @@ class ShardWordUserInterface(object):
 
     def get_name_for_shard(
             self, share_id, group_index, group_threshold, groups,
-            member_index, member_threshold
+            member_index, member_threshold, shards
             ):
-        print("")
-        print("Family: {}, Group: {}, Shard: {}".format(share_id, group_index + 1, member_index + 1))
-        return prompt('Enter name: ', **self.options).strip()
+
+        print_formatted_text("")
+        print_formatted_text("Family: {}, Group: {}, Shard: {}".format(share_id, group_index + 1, member_index + 1))
+
+        while True:
+            name = prompt('Enter name: ', **self.options).strip()
+            if name not in shards:
+                return name
+
+            print_formatted_text("Sorry, but a shard with that name already exists. Try again.")
 
     def choose_shard(self,
                      shards) -> Optional[str]:
 
         if len(shards) == 0:
-            return None
+            raise HermitError("Not enough shards to reconstruct secret.")
 
         shardnames = [shard.name for shard in shards]
         shardnames.sort()
@@ -153,7 +160,7 @@ unlock the wallet (<i>P of Q</i> groups).
 Each of the <i>Q</i> groups is itself broken into <i>m</i> shards, <i>n</i> of which are
 required to unlock the group (<i>n of m</i> shards).
 
-Unlocking the wallet requires unlocking <i>P</i> groups and unlocking each 
+Unlocking the wallet requires unlocking <i>P</i> groups and unlocking each
 group requires unlocking <i>n</i> shards for that group.
 
 You must now specify a shard configuration (such as '<i>2 of 3</i>')

--- a/hermit/shards/shard.py
+++ b/hermit/shards/shard.py
@@ -39,6 +39,32 @@ class Shard(object):
             self._unpack_share()
         return (self._group_id, self._member_id)
 
+    @property
+    def group_id(self):
+        if self._group_id is None:
+            self._unpack_share()
+        return self._group_id
+
+    @property
+    def member_threshold(self):
+        """
+        The number of members of this group needed to reconstruct the group
+        secret.
+        """
+        if self._member_threshold is None:
+            self._unpack_share()
+        return self._member_threshold
+
+    @property
+    def group_threshold(self):
+        """
+        The number of members of this group needed to reconstruct the group
+        secret.
+        """
+        if self._group_threshold is None:
+            self._unpack_share()
+        return self._group_threshold
+
     def __init__(self,
                  name: str,
                  encrypted_mnemonic: Optional[str],
@@ -60,6 +86,8 @@ class Shard(object):
         self._share_id = None
         self._group_id = None
         self._member_id = None
+        self._group_threshold = None
+        self._member_threshold = None
 
         if interface is None:
             self.interface = ShardWordUserInterface()
@@ -100,7 +128,7 @@ class Shard(object):
         return bson.dumps({self.name: self.to_bytes()})
 
     def _unpack_share(self) -> None:
-        (self._share_id, _, self._group_id, _, _, self._member_id, _,
+        (self._share_id, _, self._group_id, self._group_threshold, _, self._member_id, self._member_threshold,
          _) = shamir_share.decode_mnemonic(self.encrypted_mnemonic)
 
     def to_str(self) -> str:

--- a/hermit/ui/common.py
+++ b/hermit/ui/common.py
@@ -2,6 +2,8 @@ from .base import *
 from .wallet import wallet_command
 from .shards import shard_command
 import hermit.ui.state as state
+import traceback
+import sys
 
 @wallet_command('unlock')
 @shard_command('unlock')
@@ -13,7 +15,11 @@ def unlock():
   Many commands will do this implicitly.
 
     """
-    state.Wallet.unlock()
+    try:
+      state.Wallet.unlock()
+    except HermitError as e:
+      print_formatted_text("Unable to unlock wallet: ", e)
+      #traceback.print_exc(file=sys.stdout)
     if state.Wallet.unlocked:
         state.Timeout = DeadTime
 

--- a/tests/shards/test_shard_set.py
+++ b/tests/shards/test_shard_set.py
@@ -97,10 +97,10 @@ class TestShardSet(object):
 
         shareid = shard_set.shards['one'].share_id
         # group index 0, group threshold 1, groups 1, memberid changes, member threshold 2
-        get_name_calls = [ call(shareid,0,1,1,i,3) for i in range(3) ]
+        get_name_calls = [ call(shareid,0,1,1,i,3, shard_set.shards) for i in range(3) ]
         assert self.interface.get_name_for_shard.call_args_list == get_name_calls
 
-        assert self.interface.choose_shard.call_count == 4
+        assert self.interface.choose_shard.call_count == 3
         assert self.interface.enter_group_information.call_count == 1
 
         assert self.rg.random.call_args_list == [call(32), call(2), call(32), call(28)]
@@ -135,7 +135,7 @@ class TestShardSet(object):
         self.interface.confirm_password.side_effect = [password_1, password_2]
         self.interface.get_password.side_effect = [password_1, password_2]
         self.interface.get_name_for_shard.side_effect = ['one', 'two']
-        self.interface.choose_shard.side_effect = ['one', 'two', None]
+        self.interface.choose_shard.side_effect = ['one', 'two']
         self.interface.enter_group_information.return_value = [1,[(2,2)]]
 
         shard_set = ShardSet(self.interface)
@@ -157,10 +157,10 @@ class TestShardSet(object):
 
         shareid = shard_set.shards['one'].share_id
         # group index 0, group threshold 1, groups 1, memberid changes, member threshold 2
-        get_name_calls = [ call(shareid,0,1,1,i,2) for i in range(2) ]
+        get_name_calls = [ call(shareid,0,1,1,i,2,shard_set.shards) for i in range(2) ]
         assert self.interface.get_name_for_shard.call_args_list == get_name_calls
 
-        assert self.interface.choose_shard.call_count == 3
+        assert self.interface.choose_shard.call_count == 2
         assert self.interface.enter_group_information.call_count == 1
 
         assert self.rg.random.call_args_list == [call(2), call(28)]
@@ -170,7 +170,7 @@ class TestShardSet(object):
         self.interface.confirm_password.side_effect = [password_1, password_2]
         self.interface.get_password.side_effect = [password_1, password_2]
         self.interface.get_name_for_shard.side_effect = ['one', 'two']
-        self.interface.choose_shard.side_effect = ['one', 'two', None]
+        self.interface.choose_shard.side_effect = ['one', 'two']
         self.interface.enter_group_information.return_value = [1,[(2,2)]]
         shard_set = ShardSet(self.interface)
         shard_set._shards_loaded = True
@@ -191,10 +191,10 @@ class TestShardSet(object):
 
         shareid = shard_set.shards['one'].share_id
         # group index 0, group threshold 1, groups 1, memberid changes, member threshold 2
-        get_name_calls = [ call(shareid,0,1,1,i,2) for i in range(2) ]
+        get_name_calls = [ call(shareid,0,1,1,i,2,shard_set.shards) for i in range(2) ]
         assert self.interface.get_name_for_shard.call_args_list == get_name_calls
 
-        assert self.interface.choose_shard.call_count == 3
+        assert self.interface.choose_shard.call_count == 2
         assert self.interface.enter_group_information.call_count == 1
 
         assert self.rg.random.call_args_list == [call(2), call(28)]
@@ -220,7 +220,7 @@ class TestShardSet(object):
 
         self.interface.confirm_password.side_effect = [b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8']
         self.interface.get_name_for_shard.side_effect = ['0', '10', '11', '12', '20', '21', '22', '23', '24']
-        self.interface.choose_shard.side_effect = ['10', '12', '21', '22', '24', None]
+        self.interface.choose_shard.side_effect = ['10', '12', '21', '22', '24']
         self.interface.get_password.side_effect = [b'1', b'3', b'5', b'6', b'8']
         self.interface.enter_group_information.return_value = [2,[(1,1), (2,3), (3,5)]]
 
@@ -237,15 +237,15 @@ class TestShardSet(object):
         assert self.interface.get_password.call_count == 5
 
         share_id = shard_set.shards['0'].share_id
-        calls = ( [call(share_id, 0, 2, 3, 0, 1)]
-            + [call(share_id, 1, 2, 3, i, 2) for i in range(3)]
-            + [call(share_id, 2, 2, 3, i, 3) for i in range(5)]
+        calls = ( [call(share_id, 0, 2, 3, 0, 1, shard_set.shards)]
+            + [call(share_id, 1, 2, 3, i, 2, shard_set.shards) for i in range(3)]
+            + [call(share_id, 2, 2, 3, i, 3, shard_set.shards) for i in range(5)]
         )
 
         assert self.interface.get_name_for_shard.call_args_list == calls
         assert self.interface.get_name_for_shard.call_count == 9
 
-        assert self.interface.choose_shard.call_count == 6
+        assert self.interface.choose_shard.call_count == 5
         assert self.interface.enter_group_information.call_count == 1
 
         assert self.rg.random.call_args_list == [call(2), call(28), call(28), call(32), call(28)]


### PR DESCRIPTION
- detects unsatisfiable shard family constraints on first shard selection

- detects when shard member threshholds have been met, filters unselected group
  members from future selection

- detects group threshold satisfaction - terminates shard selection loop

- prints helpful error messages if the shard selection loop was terminated early
  or if the selected shard family is unsatisfiable with the current set of shards.