### PR TITLE
Setup TravisCI, Codecov, and some README badges

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/pybitcointools"]
 	path = vendor/pybitcointools
-	url = git@github.com:unchained-capital/pybitcointools
+	url = https://github.com/unchained-capital/pybitcointools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.7"
+before_install:
+  - sudo apt-get update
+  - make system-dependencies
+install:
+  - pip install wheel
+  - pip install codecov
+  - pip install -r requirements.frozen.txt
+script:
+  - python -m pytest --cov=hermit --cov-config=tests/.coveragerc --ignore=vendor
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Hermit
 ======
+[![PyPI](https://img.shields.io/pypi/v/hermit.svg)](https://pypi.python.org/pypi)
+[![Travis](https://img.shields.io/travis/unchained-capital/hermit.svg)](https://travis-ci.org/unchained-capital/hermit/)
+[![Codecov](https://img.shields.io/codecov/c/github/unchained-capital/hermit.svg)](https://codecov.io/gh/unchained-capital/hermit/)
 
 Hermit is a sharded,
 [HD](https://en.bitcoin.it/wiki/Deterministic_wallet) command-line

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+source=hermit
 branch = True
 omit =
     *__init__.py


### PR DESCRIPTION
I've setup TravisCI (example: https://travis-ci.org/destrys/hermit)
Codecov (example: https://codecov.io/gh/destrys/hermit/branch/travisci)

And some README badges:
Example:
<img width="329" alt="Screen Shot 2019-09-07 at 12 04 39 PM" src="https://user-images.githubusercontent.com/1590973/64479188-4a9b3380-d168-11e9-88d6-60c12fd7ec77.png">

The unchained-capital org will need to authorize both tools for them to run and the badges to update.