### PR TITLE
Bech32 outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	$(RM) -rf docs/_build/* build/* dist/* hermit.egg-info build.info
 
 freeze:
-	$(PIP) freeze > $(PYTHON_FROZEN_REQUIREMENTS)
+	$(PIP) freeze -l > $(PYTHON_FROZEN_REQUIREMENTS)
 
 dependencies: system-dependencies python-dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hermit
 ======
 [![PyPI](https://img.shields.io/pypi/v/hermit.svg)](https://pypi.python.org/pypi)
-[![Travis](https://img.shields.io/travis/unchained-capital/hermit.svg)](https://travis-ci.org/unchained-capital/hermit/)
+[![Travis](https://img.shields.io/travis/unchained-capital/hermit.svg)](https://travis-ci.com/unchained-capital/hermit/)
 [![Codecov](https://img.shields.io/codecov/c/github/unchained-capital/hermit.svg)](https://codecov.io/gh/unchained-capital/hermit/)
 
 Hermit is a sharded,

--- a/hermit/signer/bitcoin_signer.py
+++ b/hermit/signer/bitcoin_signer.py
@@ -177,6 +177,7 @@ class BitcoinSigner(Signer):
             raise InvalidSignatureRequest(err_msg)
 
         if output['address'][:2] in ('bc', 'tb'):
+            # TODO validate bech32
             err_msg = "bech32 addresses are unsupported (output)"
             raise InvalidSignatureRequest(err_msg)
         try:

--- a/requirements.frozen.txt
+++ b/requirements.frozen.txt
@@ -45,7 +45,7 @@ pyparsing==2.4.2
 pysha3==1.0.2
 pytest==4.4.0
 pytest-cov==2.6.1
-python-bitcoinlib==0.10.1
+python-bitcoinlib==0.11.0
 python-dateutil==2.8.0
 pytz==2019.2
 PyYAML==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyAesCrypt==0.4.2
 pysha3==1.0.2
 pytest-cov==2.6.1
 pytest==4.4.0
-python-bitcoinlib==0.10.1
+python-bitcoinlib==0.11.0
 PyYAML==5.1.1
 pyzbar==0.1.7
 qrcode[pil]==6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def fixture_opensource_shard_set(opensource_wallet_words):
     mock_shard_set.wallet_words.return_value = opensource_wallet_words
     return mock_shard_set
 
+
 def prep_full_vector(filename):
     with open(filename, 'r') as f:
         test_vector = json.load(f)
@@ -77,14 +78,21 @@ def prep_full_vector(filename):
                                        + "\n")
     return test_vector
 
-#@pytest.fixture()
+
+@pytest.fixture
+def fixture_opensource_bitcoin_vector():
+    return prep_full_vector(
+        "tests/fixtures/opensource_bitcoin_test_vector_0.json")
+
+
 def fixture_opensource_bitcoin_vector_0():
-    return prep_full_vector("tests/fixtures/opensource_bitcoin_test_vector_0.json")
+    return prep_full_vector(
+        "tests/fixtures/opensource_bitcoin_test_vector_0.json")
 
-#@pytest.fixture()
+
 def fixture_opensource_bitcoin_vector_1():
-    return prep_full_vector("tests/fixtures/opensource_bitcoin_test_vector_1.json")
-
+    return prep_full_vector(
+        "tests/fixtures/opensource_bitcoin_test_vector_1.json")
 
 
 @pytest.fixture(params=[fixture_opensource_bitcoin_vector_0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,17 @@ def prep_full_vector(filename):
                                        + "\n")
     return test_vector
 
-@pytest.fixture()
+#@pytest.fixture()
 def fixture_opensource_bitcoin_vector_0():
     return prep_full_vector("tests/fixtures/opensource_bitcoin_test_vector_0.json")
 
+#@pytest.fixture()
+def fixture_opensource_bitcoin_vector_1():
+    return prep_full_vector("tests/fixtures/opensource_bitcoin_test_vector_1.json")
+
+
+
+@pytest.fixture(params=[fixture_opensource_bitcoin_vector_0,
+                        fixture_opensource_bitcoin_vector_1])
+def fixture_opensource_bitcoin_vectors(request):
+    return request.param()

--- a/tests/fixtures/opensource_bitcoin_test_vector_1.json
+++ b/tests/fixtures/opensource_bitcoin_test_vector_1.json
@@ -1,46 +1,46 @@
 {
     "desciption": "p2wpkh output - TODO, make a real on-chain tx",
-    "onchain_txid": "TODO",
+    "onchain_txid": "124f679009049a9a624d32f71a141a90acd97ec0970f7c764a4a030218d0182d",
     "request": {
         "inputs": [
 	    [
-		"5221026c76fc386b6c339577eea265242eb902df43155a0eaf23af1f96c5d9f2d10f63210329b59270b95c8478fa36e0cf6f474736513d4e0157626b762dca41729e7756c22102b5b79489d0e3810ef911bfde82aad7d65e6d5fb4147686139d291f66eefd964d53ae",
-		"m/45'/1'/500'/200/26",
+		"5221021f5e253ab1d9ba7eb9101a4e00c977c625449646cbd20e5bf40c45117b398f7921034f1d22319a66bf03afcc1b2b9c62d0db0e5d0f0ddc6c85f5b6d83f9909e6c0512103c06683c5c3c0719815400cdf2ffcdc51c891701d0449bbc13a5b9be77d22a7b753ae",
+		"m/45'/1'/500'/200/42",
 		{
-                    "txid": "18c3b12c7386c085cc4a9416c03e0de6b321f6e6f0f699a9cfeafc03622ee95b",
-                    "index": 0,
-                    "amount": 2345678
-		},
-		{
-                    "txid": "54be89f3c9d9af18b26a8cbe6403ec3bdf21bbe93deb0610298722c391ec65bd",
+                    "txid": "8655048240880d946aaf8cebfc7f86e6e0955326cf2b0d624ccdbdae70e8946e",
                     "index": 1,
-                    "amount": 10000000
+                    "amount": 500000
 		},
 		{
-                    "txid": "8fbbbe11f1bde5f716c9b30aa69c9801bcbb4a7ba6b4a39a07ac3b183e16c5a8",
+                    "txid": "ae38461636aa257bf0bbe69edb26d0f99549748884820f15247f91861dce92b1",
                     "index": 0,
-                    "amount": 14388913
+                    "amount": 300000
+		},
+		{
+                    "txid": "aec22a0f902f1c4b03bd174456c39101617d7ae8d3742b00c48ff7d9c40c4507",
+                    "index": 0,
+                    "amount": 400000
 		}            
             ]
 	],
         "outputs": [
             {
-                "address": "2NCcmVAirNBDTQYvecdDpKNJVdKJruwdUSZ",
-                "amount": 12345678
+                "address": "tb1qacn2sc90qe4f723rqjwr2kf9z004xl6ftzp0nprq9cnland8udqqzxt0tg",
+                "amount": 400000
             },
             {
-                "address": "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
-                "amount": 14374378
+                "address": "tb1q0vv0vsa4ey69h4zgedd88ldd3fhz366u99tnch",
+                "amount": 799023
             }
         ]
     },
-    "expected_display": "INPUTS:\n  2NAy762TReQqjNbNLdh3sK7cnje4GA4UfoW\t0.26734591 BTC\tSigning as m/45'/1'/500'/200/26\n\n\nOUTPUTS:\n  2NCcmVAirNBDTQYvecdDpKNJVdKJruwdUSZ\t0.12345678 BTC\n  tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx\t0.14374378 BTC\n\nFEE: 0.00014535 BTC\n\nSignature Data: \n",
+    "expected_display": "INPUTS:\n  2NAK2EfXuuqF2obYVu7Xa2TjVMqVEdrGSTG\t0.012 BTC\tSigning as m/45'/1'/500'/200/42\n\n\nOUTPUTS:\n  tb1qacn2sc90qe4f723rqjwr2kf9z004xl6ftzp0nprq9cnland8udqqzxt0tg\t0.004 BTC\n  tb1q0vv0vsa4ey69h4zgedd88ldd3fhz366u99tnch\t0.00799023 BTC\n\nFEE: 0.00000977 BTC\n\nSignature Data: \n",
     "expected_signature": {
         "signatures": [
-            "30450221008b78f222bcdf18d03e12850c8600149769eebfed046b43dc9de5c5ab906f041c02206a2a75f94751fd3d2702ac1c3a4d563f40bc6911eebc40dfeed7d678522a1498",
-            "30450221009f1fa6926a6a75b1f13867c57e645f67f709491646fc876e1ceefd219e1858dd022050f389540c4fda099431437bc669f3364f8d925a56778afcb4613b95772e6e9c",
-            "304402206c1add9c084d22d28fa3e844d9b702a460bfadfc75843759657fc090417e05ce0220633e5468ca9d85440cf30099aa859651ec2eeedd8c68351b399f5e1577bf5754"
+            "3044022052d5de9239bf175a14055bca681d72c4118be5b7a17209944b30f8979a96b7a2022031461af93340f54a65adaf1dd77cd63242d731037b01a0e0007544ce4c81c296",
+            "3045022100bdf37021ead13543dba28cbe7b11f4e993d9e3a8a29fbf95e26022f95d3d23d602207e4a7f13372f6bcae059791a177b6a5d31048d2d5d2c1794729013e504cb4d24",
+            "304402203fb98b923cfee8bffff7892d02c7da6a76ffe19dea0f0f0bb08628b5acdad3b602202719c45d31648e7cc55b022486785dcf292d9386f73d0c02301865102b337517"
         ]
     },
-    "signature_label": "BTC 2NAy762TReQqjNbNLdh3sK7cnje4GA4UfoW"
+    "signature_label": "BTC 2NAK2EfXuuqF2obYVu7Xa2TjVMqVEdrGSTG"
 }

--- a/tests/fixtures/opensource_bitcoin_test_vector_1.json
+++ b/tests/fixtures/opensource_bitcoin_test_vector_1.json
@@ -1,0 +1,46 @@
+{
+    "desciption": "p2wpkh output - TODO, make a real on-chain tx",
+    "onchain_txid": "TODO",
+    "request": {
+        "inputs": [
+	    [
+		"5221026c76fc386b6c339577eea265242eb902df43155a0eaf23af1f96c5d9f2d10f63210329b59270b95c8478fa36e0cf6f474736513d4e0157626b762dca41729e7756c22102b5b79489d0e3810ef911bfde82aad7d65e6d5fb4147686139d291f66eefd964d53ae",
+		"m/45'/1'/500'/200/26",
+		{
+                    "txid": "18c3b12c7386c085cc4a9416c03e0de6b321f6e6f0f699a9cfeafc03622ee95b",
+                    "index": 0,
+                    "amount": 2345678
+		},
+		{
+                    "txid": "54be89f3c9d9af18b26a8cbe6403ec3bdf21bbe93deb0610298722c391ec65bd",
+                    "index": 1,
+                    "amount": 10000000
+		},
+		{
+                    "txid": "8fbbbe11f1bde5f716c9b30aa69c9801bcbb4a7ba6b4a39a07ac3b183e16c5a8",
+                    "index": 0,
+                    "amount": 14388913
+		}            
+            ]
+	],
+        "outputs": [
+            {
+                "address": "2NCcmVAirNBDTQYvecdDpKNJVdKJruwdUSZ",
+                "amount": 12345678
+            },
+            {
+                "address": "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+                "amount": 14374378
+            }
+        ]
+    },
+    "expected_display": "INPUTS:\n  2NAy762TReQqjNbNLdh3sK7cnje4GA4UfoW\t0.26734591 BTC\tSigning as m/45'/1'/500'/200/26\n\n\nOUTPUTS:\n  2NCcmVAirNBDTQYvecdDpKNJVdKJruwdUSZ\t0.12345678 BTC\n  tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx\t0.14374378 BTC\n\nFEE: 0.00014535 BTC\n\nSignature Data: \n",
+    "expected_signature": {
+        "signatures": [
+            "30450221008b78f222bcdf18d03e12850c8600149769eebfed046b43dc9de5c5ab906f041c02206a2a75f94751fd3d2702ac1c3a4d563f40bc6911eebc40dfeed7d678522a1498",
+            "30450221009f1fa6926a6a75b1f13867c57e645f67f709491646fc876e1ceefd219e1858dd022050f389540c4fda099431437bc669f3364f8d925a56778afcb4613b95772e6e9c",
+            "304402206c1add9c084d22d28fa3e844d9b702a460bfadfc75843759657fc090417e05ce0220633e5468ca9d85440cf30099aa859651ec2eeedd8c68351b399f5e1577bf5754"
+        ]
+    },
+    "signature_label": "BTC 2NAy762TReQqjNbNLdh3sK7cnje4GA4UfoW"
+}

--- a/tests/qrcode/test_displayer.py
+++ b/tests/qrcode/test_displayer.py
@@ -36,9 +36,9 @@ class TestDisplayQRCode(object):
     async def test_valid_qr_code(self,
                         mock_window_is_open,
                         mock_cv2,
-                        fixture_opensource_bitcoin_vector_0,
+                        fixture_opensource_bitcoin_vectors,
                         opensource_bitcoin_vector_0_array):
-        request_json = fixture_opensource_bitcoin_vector_0['request_json']
+        request_json = fixture_opensource_bitcoin_vectors['request_json']
         mock_window_is_open.return_value = True
         future = hermit.qrcode.display_qr_code(request_json)
         await future

--- a/tests/qrcode/test_reader.py
+++ b/tests/qrcode/test_reader.py
@@ -33,9 +33,9 @@ class TestReadQRCode(object):
     def test_valid_qr_code(self,
                            mock_window_is_open,
                            mock_cv2,
-                           fixture_opensource_bitcoin_vectors,
+                           fixture_opensource_bitcoin_vector,
                            opensource_bitcoin_vector_0_image):
-        request_json = fixture_opensource_bitcoin_vectors['request_json']
+        request_json = fixture_opensource_bitcoin_vector['request_json']
         mock_cv2.VideoCapture().read.return_value = (
             None, np.array(opensource_bitcoin_vector_0_image))
         mock_cv2.resize.return_value = opensource_bitcoin_vector_0_image

--- a/tests/qrcode/test_reader.py
+++ b/tests/qrcode/test_reader.py
@@ -33,9 +33,9 @@ class TestReadQRCode(object):
     def test_valid_qr_code(self,
                            mock_window_is_open,
                            mock_cv2,
-                           fixture_opensource_bitcoin_vector_0,
+                           fixture_opensource_bitcoin_vectors,
                            opensource_bitcoin_vector_0_image):
-        request_json = fixture_opensource_bitcoin_vector_0['request_json']
+        request_json = fixture_opensource_bitcoin_vectors['request_json']
         mock_cv2.VideoCapture().read.return_value = (
             None, np.array(opensource_bitcoin_vector_0_image))
         mock_cv2.resize.return_value = opensource_bitcoin_vector_0_image

--- a/tests/signer/test_bitcoin_signer.py
+++ b/tests/signer/test_bitcoin_signer.py
@@ -26,11 +26,11 @@ class TestBitcoinSignerValidation(object):
 
     @pytest.fixture(autouse=True)
     def setup_wallet_and_request(self,
-                                 fixture_opensource_bitcoin_vector_0,
+                                 fixture_opensource_bitcoin_vectors,
                                  opensource_wallet_words):
         self.wallet = HDWallet()
         self.wallet.shards = FakeShards(opensource_wallet_words)
-        self.request = fixture_opensource_bitcoin_vector_0['request']
+        self.request = fixture_opensource_bitcoin_vectors['request']
 
     #
     # Input Groups

--- a/tests/signer/test_bitcoin_signer.py
+++ b/tests/signer/test_bitcoin_signer.py
@@ -20,17 +20,17 @@ class FakeShards:
     def wallet_words(self):
         return self.words
 
-        
+
 @patch('hermit.signer.reader.read_qr_code')
 class TestBitcoinSignerValidation(object):
 
     @pytest.fixture(autouse=True)
     def setup_wallet_and_request(self,
-                                 fixture_opensource_bitcoin_vectors,
+                                 fixture_opensource_bitcoin_vector,
                                  opensource_wallet_words):
         self.wallet = HDWallet()
         self.wallet.shards = FakeShards(opensource_wallet_words)
-        self.request = fixture_opensource_bitcoin_vectors['request']
+        self.request = fixture_opensource_bitcoin_vector['request']
 
     #
     # Input Groups
@@ -549,24 +549,62 @@ class TestBitcoinSignerValidation(object):
         mock_request.return_value = json.dumps(self.request)
         BitcoinSigner(self.wallet).sign(testnet=False)
 
+    @patch('hermit.signer.displayer.display_qr_code')    
+    @patch('hermit.signer.base.input')    
+    def test_valid_segwit_testnet_output_address_types(self,
+                                                       mock_input,
+                                                       mock_display_qr_code,
+                                                       mock_request):
+        mock_input.return_value = 'y'
+        mock_request.return_value = json.dumps(self.request)
+        BitcoinSigner(self.wallet).sign(testnet=True)
+        
+        self.request['outputs'][1]['address'] = "tb1q0vv0vsa4ey69h4zgedd88ldd3fhz366u99tnch"
+        self.request['outputs'][0]['address'] = "tb1qacn2sc90qe4f723rqjwr2kf9z004xl6ftzp0nprq9cnland8udqqzxt0tg"
+        mock_request.return_value = json.dumps(self.request)
+        BitcoinSigner(self.wallet).sign(testnet=True)
 
-    def test_output_bech_addresses_error(self, mock_request):
+
+    @patch('hermit.signer.displayer.display_qr_code')    
+    @patch('hermit.signer.base.input')    
+    def test_valid_segwit_mainnet_output_address_types(self,
+                                                       mock_input,
+                                                       mock_display_qr_code,
+                                                       mock_request):
+        mock_input.return_value = 'y'
+        mock_request.return_value = json.dumps(self.request)
+        BitcoinSigner(self.wallet).sign(testnet=True)
+        
+        self.request['outputs'][1]['address'] = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+        self.request['outputs'][0]['address'] = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+        mock_request.return_value = json.dumps(self.request)
+        BitcoinSigner(self.wallet).sign(testnet=False)
+
+        
+    def test_invalid_output_bech_addresses_error(self, mock_request):
         bech_addr = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
         self.request['outputs'][0]['address'] = bech_addr
         mock_request.return_value = json.dumps(self.request)
         with pytest.raises(hermit.errors.InvalidSignatureRequest) as e_info1:
-            BitcoinSigner(self.wallet).sign(testnet=False)
+            BitcoinSigner(self.wallet).sign(testnet=True)
 
         test_bech_addr = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
         self.request['outputs'][0]['address'] = test_bech_addr
         mock_request.return_value = json.dumps(self.request)
         with pytest.raises(hermit.errors.InvalidSignatureRequest) as e_info2:
+            BitcoinSigner(self.wallet).sign(testnet=False)
+
+        test_bech_addr = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsxaaa'
+        self.request['outputs'][0]['address'] = test_bech_addr
+        mock_request.return_value = json.dumps(self.request)
+        with pytest.raises(hermit.errors.InvalidSignatureRequest) as e_info3:
             BitcoinSigner(self.wallet).sign(testnet=True)
-            
+
         expected = ("Invalid signature request: "
-                    + "bech32 addresses are unsupported (output).")
+                    + "invalid bech32 output address (check mainnet vs. testnet).")
         assert str(e_info1.value) == expected
         assert str(e_info2.value) == expected
+        assert str(e_info3.value) == expected
                 
     def test_wrong_network_address_type_errors(self, mock_request):
         mock_request.return_value = json.dumps(self.request)

--- a/tests/signer/test_echo_signer.py
+++ b/tests/signer/test_echo_signer.py
@@ -14,10 +14,10 @@ class TestEchoSigner(object):
                                         mock_request,
                                         mock_input,
                                         mock_display_qr_code,
-                                        fixture_opensource_bitcoin_vector_0,
+                                        fixture_opensource_bitcoin_vectors,
                                         fixture_opensource_shard_set,
                                         capsys):
-        request_json = fixture_opensource_bitcoin_vector_0['request_json']
+        request_json = fixture_opensource_bitcoin_vectors['request_json']
         wallet = HDWallet()
         wallet.shards = fixture_opensource_shard_set
         mock_request.return_value = request_json

--- a/tests/test_functional_bitcoin_tests.py
+++ b/tests/test_functional_bitcoin_tests.py
@@ -18,11 +18,11 @@ class TestBitcoinSigningIntegration(object):
                                         mock_input,
                                         mock_display_qr_code,
                                         fixture_opensource_shard_set,
-                                        fixture_opensource_bitcoin_vector_0,
+                                        fixture_opensource_bitcoin_vectors,
                                         capsys):
         # TODO: use an actual shard_file
         # TODO: move to all opensource vectors
-        test_vector = fixture_opensource_bitcoin_vector_0
+        test_vector = fixture_opensource_bitcoin_vectors
         wallet = HDWallet()
         wallet.shards = fixture_opensource_shard_set
         mock_request.return_value = test_vector['request_json']


### PR DESCRIPTION
This PR gives hermit the ability to sign transaction with bech32 outputs (both p2wsh and p2wpkh). An on-chain testnet transaction has been added to the fixtures.

The signing code didn't need to change, thanks to python-bitcoinlib adding bech32 addresses with release 0.11.0. Our validation function did need to be updated.
Note that python-bitcoinlib doesn't differentiate between an incorrect network, an invalid checksum, or an invalid string for bech32 decoding, so for all these cases we return the same error message.