### PR TITLE
Fix: Persistence layer creates zero-length initial shards file

### DIFF
--- a/hermit/shards/shard_set.py
+++ b/hermit/shards/shard_set.py
@@ -69,7 +69,7 @@ class ShardSet(object):
             # If for some reason the persistence layer failed to  create the
             # the shards file, we assume that we just need to initialize
             # it as an empty bson object.
-            if not os.path.exists(self.config.shards_file):
+            if not os.path.exists(self.config.shards_file) or os.stat(self.config.shards_file).st_size == 0:
                 with open(self.config.shards_file, 'wb') as f:
                     f.write(bson.dumps({}))
 


### PR DESCRIPTION
I was running into an issue when running hermit in several different environments (docker on Win10, docker on Ubuntu, Ubuntu, PyCharm on Ubuntu): hermit was not initializing the shards_file properly (with empty bson) and the UI was choking on it.  Turns out that the persistence layer command was resulting in an empty initial file being created, and the existing code didn't catch it because it was only checking for the existence of the file.