### PR TITLE
Optionally remove information from the signed psbt.

### DIFF
--- a/hermit/config.py
+++ b/hermit/config.py
@@ -115,11 +115,18 @@ class HermitConfig:
     #:    during signing.  Options are `old`, `long`, and `short`, with the
     #:    default being `old`.
     #:
+    #: * 'minimize_signed_psbt' -- controls whether or not to remove information
+    #:   from the signed psbt that the coordinator should already be aware of
+    #:   because they should still have a copy of the unsigned psbt that they
+    #:   sent for us to sign.  In some cases this can DRAMATICALLY reduce the
+    #:   amount of information that needs to be sent back over the return QR
+    #:   channel."
     DefaultCoordinator: Dict[str, Union[str, bool, None, int]] = {
         "signature_required": False,
         "public_key": None,
         "transaction_display": "old",
         "relock_timeout": 30,  # seconds
+        "minimize_signed_psbt": False,
     }
 
     @classmethod

--- a/hermit/config.py
+++ b/hermit/config.py
@@ -120,7 +120,7 @@ class HermitConfig:
     #:   because they should still have a copy of the unsigned psbt that they
     #:   sent for us to sign.  In some cases this can DRAMATICALLY reduce the
     #:   amount of information that needs to be sent back over the return QR
-    #:   channel."
+    #:   channel.
     DefaultCoordinator: Dict[str, Union[str, bool, None, int]] = {
         "signature_required": False,
         "public_key": None,

--- a/hermit/signer.py
+++ b/hermit/signer.py
@@ -16,6 +16,7 @@ from .config import get_config
 _satoshis_per_bitcoin = Decimal(int(pow(10, 8)))
 
 transaction_display_mode = get_config().coordinator["transaction_display"]
+minimize_signed_psbt = get_config().coordinator["minimize_signed_psbt"]
 TOPROW = "╔═╗"
 MIDDLE = "║ ║"
 SECTION = "╠═╣"
@@ -503,6 +504,12 @@ class Signer(object):
         )
         if was_signed is False:
             raise HermitError("Failed to sign transaction")
+
+        if minimize_signed_psbt:
+            for inp in self.psbt.psbt_ins:
+                inp.prev_tx = None
+                inp.redeem_script = None
+                inp.named_pubs = {}
 
         if self.psbt is not None:
             self.signed_psbt_b64 = self.psbt.serialize_base64()

--- a/hermit/signer.py
+++ b/hermit/signer.py
@@ -505,13 +505,15 @@ class Signer(object):
         if was_signed is False:
             raise HermitError("Failed to sign transaction")
 
-        if minimize_signed_psbt:
-            for inp in self.psbt.psbt_ins:
-                inp.prev_tx = None
-                inp.redeem_script = None
-                inp.named_pubs = {}
 
         if self.psbt is not None:
+
+            if minimize_signed_psbt:
+                for inp in self.psbt.psbt_ins:
+                    inp.prev_tx = None
+                    inp.redeem_script = None
+                    inp.named_pubs = {}
+
             self.signed_psbt_b64 = self.psbt.serialize_base64()
 
     def show_signature(self) -> None:

--- a/hermit/signer.py
+++ b/hermit/signer.py
@@ -513,7 +513,9 @@ class Signer(object):
                     inp.prev_tx = None
                     inp.redeem_script = None
                     inp.named_pubs = {}
-
+                    inp.prev_out = None
+                    inp.witness_script = None
+                    inp.extra_map = {}
             self.signed_psbt_b64 = self.psbt.serialize_base64()
 
     def show_signature(self) -> None:


### PR DESCRIPTION
Removes information that the coordinator should already be aware of, but
were needed to validate information in the transaction before we signed.